### PR TITLE
Add Spring Cloud Gateway proxy route

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,29 @@
 
     <properties>
         <java.version>21</java.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/demo/config/GatewayConfig.java
+++ b/src/main/java/com/example/demo/config/GatewayConfig.java
@@ -1,0 +1,22 @@
+package com.example.demo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayConfig {
+
+    @Bean
+    public RouteLocator customRouteLocator(RouteLocatorBuilder builder,
+                                           @Value("${proxy.target.uri}") String targetUri) {
+        return builder.routes()
+                .route("proxy", r -> r
+                        .path("/proxy/**")
+                        .filters(f -> f.rewritePath("/proxy(?<segment>/.*)", "${segment}"))
+                        .uri(targetUri))
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+# Target URI for gateway proxy
+proxy.target.uri=https://example.com


### PR DESCRIPTION
## Summary
- integrate Spring Cloud Gateway dependencies
- add gateway config that proxies `/proxy/**` to a target URI
- configure default `proxy.target.uri` in `application.properties`
- update Spring Cloud BOM to latest GA version `2024.0.0`

## Testing
- `mvn -v` *(fails: command not found)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401001328c832ebaeca2c5793a276d